### PR TITLE
fixed typo/error in error codes table

### DIFF
--- a/docs/payments-refunds/error-codes.md
+++ b/docs/payments-refunds/error-codes.md
@@ -29,7 +29,7 @@ If any client errors occur, our endpoints return an error object describing the 
 | invalid_payment_state   | Only initiated payments can be cancelled by idempotency key. |
 | invalid_payment_state   | Only reserved payments can be captured. |
 | invalid_payment_point   | Payment point is not active. |
-| payment_point_not_found  | Payment does not exist. |
+| payment_point_not_found  | Payment point does not exist. |
 | idempotency_key_reused   | Different request parameters already used for the same idempotencyKey - {_idempotencyKey_}. |
 | unauthorized_access   | Authorization error occurred. |
 | payment_captured_with_different_amount   | Payment has already been captured with different amount. |
@@ -42,7 +42,6 @@ If any client errors occur, our endpoints return an error object describing the 
 | amount_too_large  | Cannot refund more than the remaining amount of payment - {_remaining payment amount_}. |
 | payment_not_found  | Payment does not exist. |
 | invalid_payment_state   | Payment has not been captured yet and cannot be refunded. |
-| payment_point_not_found  | Payment does not exist. |
 | idempotency_key_reused   | Different request parameters already used for the same idempotencyKey - {_idempotencyKey_}. |
 | unauthorized_access   | Authorization error occurred. |
 


### PR DESCRIPTION
We do not return "payment_point_not_found" code in Merchant.Payments.Refunds