### PR TITLE
Update query parameter format from date-time to date

### DIFF
--- a/openapi/reporting.yaml
+++ b/openapi/reporting.yaml
@@ -7,7 +7,8 @@ info:
     #### General notes
 
     All dates use the (`ISO 8601-1:2019`) format.<br/>
-    Date-time format - `YYYY-MM-DDTHH:mm:ssZ` or `YYYY-MM-DDTHH:mm:ss+00:00`.
+    Date format - `YYYY-MM-DD`.<br/>
+    Date-time format - `YYYY-MM-DDTHH:mm:ssZ` or `YYYY-MM-DDTHH:mm:ss+00:00`.<br/>
   contact:
     email: developer@mobilepay.dk
   version: v3
@@ -69,12 +70,14 @@ paths:
           in: query
           schema:
             type: string
-            format: date-time
+            format: date
+            example: 2021-11-30
         - name: enddate
           in: query
           schema:
             type: string
-            format: date-time
+            format: date
+            example: 2021-11-30
         - name: pagesize
           in: query
           description: Number of transactions to be returned.
@@ -117,12 +120,14 @@ paths:
           in: query
           schema:
             type: string
-            format: date-time
+            format: date
+            example: 2021-11-30
         - name: enddate
           in: query
           schema:
             type: string
-            format: date-time
+            format: date
+            example: 2021-11-30
         - name: reference
           in: query
           description: Bank reference number used for aggregated transfer to receiver account.

--- a/openapi/reporting.yaml
+++ b/openapi/reporting.yaml
@@ -70,14 +70,12 @@ paths:
           in: query
           schema:
             type: string
-            format: date
-            example: 2021-11-30
+            format: date-time
         - name: enddate
           in: query
           schema:
             type: string
-            format: date
-            example: 2021-11-30
+            format: date-time
         - name: pagesize
           in: query
           description: Number of transactions to be returned.


### PR DESCRIPTION
The query parameters were incorrectly marked as format `date-time` while the only accepted format was in fact a simple `date`