### PR TITLE
Fix incorrect json key name

### DIFF
--- a/docs/reporting/payment-points.md
+++ b/docs/reporting/payment-points.md
@@ -19,7 +19,7 @@ $ curl -X 'GET' \
 {
   "pageSize": 1,
   "nextPageNumber": 2,
-  "paymentpoints": [
+  "paymentPoints": [
     {
       "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
       "name": "Product store",


### PR DESCRIPTION
Rename incorrect json key `paymentpoints` to the correct `paymentPoints` (capital P)